### PR TITLE
Fix navigation when value is outside allowed range

### DIFF
--- a/packages/react-widgets/src/Calendar.js
+++ b/packages/react-widgets/src/Calendar.js
@@ -330,8 +330,9 @@ class Calendar extends React.Component {
     let { value, min, max } = this.props
     let { view } = this.state
     value = inRangeValue(value, min, max)
+    const oldValue = inRangeValue(prevProps.value, prevProps.min, prevProps.max); 
 
-    if (!dates.eq(value, dateOrNull(prevProps.value), VIEW_UNIT[view]))
+    if (!dates.eq(value, oldValue, VIEW_UNIT[view]))
       this.maybeSetCurrentDate(value)
   }
 


### PR DESCRIPTION
React widgets v5 example below where this is also an issue since it's easier to test in say https://jquense.github.io/react-widgets/docs/DatePicker#min:
```
<DatePicker 
  min={new Date(2021,10,30)}
  defaultValue={new Date(2021, 5, 20)}
/>;
```

We are however using V4 and its time picker and would appreciate if this can get patched there as well without having to create a fork.